### PR TITLE
kubevirt: bump default version to v0.19.0

### DIFF
--- a/ci/defaults
+++ b/ci/defaults
@@ -2,7 +2,7 @@ DEFAULT_PLATFORM=minikube
 DEFAULT_CLUSTER=kubernetes
 # Intentionally unset, as set my platform usually
 DEFAULT_CLUSTER_VERSION=
-DEFAULT_KUBEVIRT_VER=v0.17.0
+DEFAULT_KUBEVIRT_VER=v0.19.0
 
 declare -A CDIST_ON
 CDIST_ON[minikube]=kubernetes


### PR DESCRIPTION
Intentionally not on bleeding edge, but modern enough still.

Signed-off-by: Francesco Romani <fromani@redhat.com>