### PR TITLE
traviskube: always self-test against last k6t

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ before_script:
 ### And https://github.com/LiliC/travis-minikube/blob/e0f26f7b388057f51a0e2558afd5f990e07b6c49/.travis.yml#L11
 - sudo mount --make-rshared /
 
+- bash -x ci/extra/get-kubevirt-releases
+
 - bash -x ci/prepare-host $CPLATFORM
 - bash -x ci/prepare-host virtctl
 - bash -x ci/start-cluster $CPLATFORM $CVER

--- a/ci/defaults
+++ b/ci/defaults
@@ -2,7 +2,7 @@ DEFAULT_PLATFORM=minikube
 DEFAULT_CLUSTER=kubernetes
 # Intentionally unset, as set my platform usually
 DEFAULT_CLUSTER_VERSION=
-DEFAULT_KUBEVIRT_VER=v0.19.0
+DEFAULT_KUBEVIRT_VER=
 
 declare -A CDIST_ON
 CDIST_ON[minikube]=kubernetes

--- a/ci/deploy-kubevirt
+++ b/ci/deploy-kubevirt
@@ -10,6 +10,11 @@ if [ -z "${DEPLOY_TIMEOUT}" ]; then
 	DEPLOY_TIMEOUT="240s"
 fi
 
+if [ -z "${DEFAULT_KUBEVIRT_VER}" ]; then
+	# if no versionsrc available, DEFAULT_KUBEVIRT_VER will still be ""
+	DEFAULT_KUBEVIRT_VER="$( $(dirname $(realpath $0))/extra/cat-kubevirt-release last )"
+fi
+
 _enable_software_emulation() {
   kubectl create configmap -n kubevirt kubevirt-config --from-literal debug.useEmulation=true || :
 }


### PR DESCRIPTION
Let's try to catch bugs like the one fixed in
https://github.com/fromanirh/traviskube/pull/3
earlier

Signed-off-by: Francesco Romani <fromani@redhat.com>