### PR TITLE
extra: versions: make the helpers more robust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ branches:
 jobs:
   include:
     - stage: Tests
-      name: "Default (minikube with latest k8s)"
+      name: "minishift (latest okd)"
+      env: CPLATFORM=minishift
 
     - name: "oc cluster (latest okd)"
       env: CPLATFORM=oc_cluster
 
-    - name: "minishift (latest okd)"
-      env: CPLATFORM=minishift
+      #    - name: "Default (minikube with latest k8s)"
 
 cache:
   directories:

--- a/ci/extra/cat-kubevirt-release
+++ b/ci/extra/cat-kubevirt-release
@@ -3,7 +3,7 @@
 
 set -e
 
-[ ! -f versionsrc ] && exit 1
+[ ! -s versionsrc ] && exit 1
 
 case "$1" in
 last)

--- a/ci/extra/find-versions.py
+++ b/ci/extra/find-versions.py
@@ -22,8 +22,8 @@ class Version(_version):
 
 
 def versions(data):
-    tags = [ item['tag_name'] for item in data ]
-    versions = [ Version.from_string(tag) for tag in tags]
+    tags = [ item.get('tag_name', '') for item in data ]
+    versions = [ Version.from_string(tag) for tag in tags if tag]
     buckets = {}
     for ver in versions:
         key = (ver.major, ver.minor)
@@ -52,6 +52,9 @@ def _has_arg():
 def _main():
     builtin = Version.from_string(sys.argv[1]) if _has_arg() else None
     vers = versions(json.load(sys.stdin))
+    if not vers:
+        return
+
     secondlast = vers[1] if len(vers) >= 1 else vers[0]
     out = {
             'last': vers[0],


### PR DESCRIPTION
Make the helper scripts handle better the failure conditions,
e.g. github returning empty content, instead of just stacktracing.
This should help troubleshooting CI issues.

proper tests still pending.

Signed-off-by: Francesco Romani <fromani@redhat.com>