### PR TITLE
deploy: add helper to get the right wait condition

### DIFF
--- a/ci/deploy-kubevirt
+++ b/ci/deploy-kubevirt
@@ -49,8 +49,9 @@ _origin() {
 _${CDIST_ON[${1:-$DEFAULT_PLATFORM}]} ${2:-$DEFAULT_KUBEVIRT_VER}
 
 
+WAIT_CONDITION=$( $(dirname $(realpath $0))/extra/get-wait-condition.py ${2:-$DEFAULT_KUBEVIRT_VER} )
 (
-  kubectl wait --timeout=${DEPLOY_TIMEOUT} --for=condition=Available -n kubevirt kv/kubevirt ;
+  kubectl wait --timeout=${DEPLOY_TIMEOUT} --for=condition=${WAIT_CONDITION} -n kubevirt kv/kubevirt ;
 ) || {
   echo "Something went wrong"
   kubectl describe -n kubevirt kv/kubevirt

--- a/ci/extra/get-wait-condition.py
+++ b/ci/extra/get-wait-condition.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+import collections
+import sys
+
+
+_version = collections.namedtuple('_version', ['major', 'minor', 'micro'])
+
+
+class Version(_version):
+
+    @classmethod
+    def from_string(cls, text):
+        text = text.lstrip("v")
+        text = text.split("-")[0]  # TODO: handle '-extra'?
+        major, minor, micro = text.split('.')
+        return cls(int(major), int(minor), int(micro))
+
+    def __str__(self):
+        return "v%d.%d.%d" % (self.major, self.minor, self.micro)
+
+
+def _main():
+    # see: https://kubevirt.io/user-guide/docs/latest/administration/intro.html#cluster-side-add-on-deployment
+    cutoff = Version.from_string("v0.20.0")
+    try:
+        current = Version.from_string(sys.argv[1])
+    except (IndexError, ValueError):
+        # FIXME: that's bad practice
+        sys.exit(1)
+
+    print('Available' if current >= cutoff else 'Ready')
+
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
Until we support upgrades from before v0.20.0,
we need to pick the right wait condition to avoid
false failures on CI.

Signed-off-by: Francesco Romani <fromani@redhat.com>