### PR TITLE
added -f param to curl when fetching kubevirt versions

### DIFF
--- a/ci/extra/get-kubevirt-releases
+++ b/ci/extra/get-kubevirt-releases
@@ -10,9 +10,9 @@ elif [ -f "go.mod" ]; then
 fi
 
 if [ -n "${GITHUB_TOKEN}" ]; then
-	curl -H "Authorization: token ${GITHUB_TOKEN}" --silent -k "https://api.github.com/repos/kubevirt/kubevirt/releases" > releases.json
+	curl -fH "Authorization: token ${GITHUB_TOKEN}" --silent -k "https://api.github.com/repos/kubevirt/kubevirt/releases" > releases.json
 else
-	curl --silent -k "https://api.github.com/repos/kubevirt/kubevirt/releases" > releases.json
+	curl --silent -fk "https://api.github.com/repos/kubevirt/kubevirt/releases" > releases.json
 fi
 
 $(dirname $(realpath $0))/find-versions.py "${BUILTIN_VERSION}" < releases.json > versionsrc


### PR DESCRIPTION
Sometimes when github rates are exceeded, script (get-kubevirt-releases) saves error response into releases.json file.
This change should stop script immediately after receiving 4XX status code from github api.

Signed-off-by: ksimon1 <ksimon@redhat.com>
cc @fromanirh 